### PR TITLE
Providing an example of parsing properties of Order with primitive types

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+# To learn more about .editorconfig see https://aka.ms/editorconfigdocs
+root = true
+
+# All files
+[*]
+indent_style = space
+indent_size = 2
+

--- a/RapideFix.sln
+++ b/RapideFix.sln
@@ -7,7 +7,12 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RapideFix", "src\RapideFix\
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SampleRapideFix", "samples\SampleRapideFix\SampleRapideFix.csproj", "{CAA108E9-953E-402C-9CF6-F8E4D8013AA7}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RapidFixFixture", "tests\RapidFixFixture\RapidFixFixture.csproj", "{6EB73ADF-005C-4239-92AF-34EDA1E0AF9D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RapidFixFixture", "tests\RapidFixFixture\RapidFixFixture.csproj", "{6EB73ADF-005C-4239-92AF-34EDA1E0AF9D}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{CEC862DD-7066-4735-8790-33BE78C200FB}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/samples/SampleRapideFix/Data/Leg.cs
+++ b/samples/SampleRapideFix/Data/Leg.cs
@@ -1,4 +1,4 @@
-﻿using RapideFix;
+﻿using RapideFix.Attributes;
 
 namespace SampleRapideFix.Data
 {

--- a/samples/SampleRapideFix/Data/Order.cs
+++ b/samples/SampleRapideFix/Data/Order.cs
@@ -1,4 +1,4 @@
-﻿using RapideFix;
+﻿using RapideFix.Attributes;
 using System.Collections.Generic;
 
 namespace SampleRapideFix.Data

--- a/samples/SampleRapideFix/Program.cs
+++ b/samples/SampleRapideFix/Program.cs
@@ -11,7 +11,7 @@ namespace SampleRapideFix
       settings.RegisterMessageTypes<Order>();
 
       var parser = new FixParser(settings);
-      parser.Parse<Order>("8=FIX.4.2|9=19|35=D|55=AAPL|54=12|10=186|");
+      parser.Parse<Order>("8=FIX.4.2|9=19|35=D|55=AAPL|54=1|10=186|1=account1|44=12.5|");
     }
   }
 }

--- a/samples/SampleRapideFix/SampleRapideFix.csproj
+++ b/samples/SampleRapideFix/SampleRapideFix.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/RapideFix/Attributes/FixTagAttribute.cs
+++ b/src/RapideFix/Attributes/FixTagAttribute.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace RapideFix
+namespace RapideFix.Attributes
 {
   [AttributeUsage(AttributeTargets.Property, AllowMultiple = true)]
   public class FixTagAttribute : Attribute

--- a/src/RapideFix/Attributes/MessageTypeAttribute.cs
+++ b/src/RapideFix/Attributes/MessageTypeAttribute.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace RapideFix
+namespace RapideFix.Attributes
 {
   [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
   public class MessageTypeAttribute : Attribute

--- a/src/RapideFix/Constant.cs
+++ b/src/RapideFix/Constant.cs
@@ -3,6 +3,8 @@
   internal static class Constant
   {
     internal const char SOHChar = '\u0001';
+    internal const char VerticalBar = '|';
+    internal const char Equal = '=';
 
     internal const byte SOHByte = 1;
 

--- a/src/RapideFix/FixParser.cs
+++ b/src/RapideFix/FixParser.cs
@@ -1,20 +1,40 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Buffers.Text;
+using RapideFix.StringProcessing;
+using RapideFix.Attributes;
 
 namespace RapideFix
 {
   public class FixParser
   {
     private readonly FixParserSettings _settings;
-
+    
     public FixParser(FixParserSettings settings)
     {
       _settings = settings;
     }
 
-    public TMessage Parse<TMessage>(string data)
+    public TMessage Parse<TMessage>(string data) where TMessage : new()
     {
-      throw new NotImplementedException();
+      TMessage message = new TMessage();
+      Dictionary<int, PropertyInfo> tagFixTagAttributeMap = GetPropertyFixTagAttributes(typeof(TMessage));
+
+      foreach (ReadOnlyMemory<char> item in new FixStringEnumerable(data))
+      {
+        (ReadOnlyMemory<char> fixTagChars, ReadOnlyMemory<char> value) = item.GetTagAndValue();
+        int fixTag = int.Parse(fixTagChars.Span);
+
+        if (tagFixTagAttributeMap.TryGetValue(fixTag, out var propertyInfo))
+        {
+          propertyInfo.SetValue(message, Parse(propertyInfo.PropertyType, value));
+        }
+      }
+
+      return message;
     }
 
     public TMessage Parse<TMessage>(byte[] data)
@@ -27,5 +47,47 @@ namespace RapideFix
       throw new NotImplementedException();
     }
 
+    private ReadOnlySpan<char> GetNextElement(int start, string str)
+    {
+      return str.AsSpan(start, str.IndexOf(Constant.VerticalBar, start)-start);
+    }
+
+    #region Private Methods
+
+    private ReadOnlySpan<char> GetValue(ReadOnlySpan<char> element)
+    {
+      int index = element.IndexOf(Constant.Equal) + 1;
+      return element.Slice(index, element.Length - index);
+    }
+
+    private Dictionary<int, PropertyInfo> GetPropertyFixTagAttributes(Type type)
+    {
+      Dictionary<int, PropertyInfo> fixTagPropertyInfoMap = new Dictionary<int, PropertyInfo>();
+      PropertyInfo[] properties = type.GetProperties();
+
+      foreach (PropertyInfo propertyInfo in properties)
+      {
+        FixTagAttribute fixTagAttribute = (FixTagAttribute)propertyInfo.GetCustomAttribute(typeof(FixTagAttribute), false);
+        fixTagPropertyInfoMap.Add(fixTagAttribute.Tag, propertyInfo);
+      }
+
+      return fixTagPropertyInfoMap;
+    }
+
+    private object Parse(Type type, ReadOnlyMemory<char> value)
+    {
+      switch (type.Name)
+      {
+        case "Int32":
+          return int.Parse(value.Span);
+        case "String":
+          return value.Span.ToString();
+        case "Double":
+          return double.Parse(value.ToString()); //Span has issues with double parsing right now
+      }
+      return null;
+    }
+
+    #endregion
   }
 }

--- a/src/RapideFix/RapideFix.csproj
+++ b/src/RapideFix/RapideFix.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/src/RapideFix/StringProcessing/FixStringEnumerable.cs
+++ b/src/RapideFix/StringProcessing/FixStringEnumerable.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace RapideFix.StringProcessing
+{
+  public class FixStringEnumerable : IEnumerable<ReadOnlyMemory<char>>
+  {
+    private readonly string _fixString;
+
+    public FixStringEnumerable(string fixString)
+    {
+      _fixString = fixString;
+    }
+
+    public IEnumerator<ReadOnlyMemory<char>> GetEnumerator() => new FixStringEnumerator(_fixString);
+
+    IEnumerator IEnumerable.GetEnumerator() => new FixStringEnumerator(_fixString);
+  }
+}

--- a/src/RapideFix/StringProcessing/FixStringEnumerator.cs
+++ b/src/RapideFix/StringProcessing/FixStringEnumerator.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace RapideFix.StringProcessing
+{
+  public sealed class FixStringEnumerator : IEnumerator<ReadOnlyMemory<char>>
+  {
+    #region Declarations
+
+    private readonly string _fixString;
+
+    private int _index = 0;
+
+    #endregion
+
+    #region Constructors
+
+    public FixStringEnumerator(string fixString)
+    {
+      _fixString = fixString ?? throw new ArgumentNullException(nameof(fixString));
+    }
+
+    #endregion
+
+    #region IEnumerator Properties
+
+    public ReadOnlyMemory<char> Current { get; private set; }
+
+    object IEnumerator.Current => Current;
+
+    #endregion
+
+    #region IEnumerator Methods
+
+    public void Dispose() { }
+
+    public bool MoveNext()
+    {
+      if (_index < _fixString.Length)
+      {
+        int nextSeparator = _fixString.IndexOf(Constant.VerticalBar, _index);
+        if (0 < nextSeparator)
+        {
+          Current = _fixString.AsMemory(_index, nextSeparator - _index);
+          _index = nextSeparator + 1;
+          return true;
+        }
+      }
+
+      return false;
+    }
+
+    public void Reset()
+    {
+      _index = 0;
+      Current = null;
+    }
+
+    #endregion
+  }
+}

--- a/src/RapideFix/StringProcessing/ReadonlyMemoryExtensions.cs
+++ b/src/RapideFix/StringProcessing/ReadonlyMemoryExtensions.cs
@@ -1,0 +1,30 @@
+﻿using System;
+
+namespace RapideFix.StringProcessing
+{
+  public static class ReadOnlyMemoryExtensions
+  {
+    public static ReadOnlyMemory<char> GetTag<T>(this ReadOnlyMemory<char> fixElement)
+    {
+      int tagValueSeparatorIndex = fixElement.GetTagValueSeparatorIndex();
+      return fixElement.Slice(0, tagValueSeparatorIndex);
+    }
+
+    public static ReadOnlyMemory<char> GetValue<T>(this ReadOnlyMemory<char> fixElement)
+    {
+      int tagValueSeparatorIndex = fixElement.GetTagValueSeparatorIndex();
+      return fixElement.Slice(tagValueSeparatorIndex + 1);
+    }
+
+    public static (ReadOnlyMemory<char> tag, ReadOnlyMemory<char> value) GetTagAndValue(this ReadOnlyMemory<char> fixElement)
+    {
+      int tagValueSeparatorIndex = fixElement.GetTagValueSeparatorIndex();
+      return (fixElement.Slice(0, tagValueSeparatorIndex), fixElement.Slice(tagValueSeparatorIndex + 1));
+    }
+
+    private static int GetTagValueSeparatorIndex(this ReadOnlyMemory<char> fixElement)
+    {
+      return fixElement.Span.IndexOf(Constant.Equal);
+    }
+  }
+}

--- a/tests/RapidFixFixture/RapidFixFixture.csproj
+++ b/tests/RapidFixFixture/RapidFixFixture.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
@@ -16,6 +16,10 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\RapideFix\RapideFix.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
FixStringEnumerator: Provides an enumerator over a FIX string. On each enumeration it will return the next element of fix string, separated with vertical bar.
FixStringEnumerable: Provides an enumerable over a FIX string using FixStringEnumerator.
ReadonlyMemoryExtensions: Extension methods for ReadonlyMemory<char> representing a FIX element to get FIX tag and value of the element.

Added implementation of FIX string parser in FixParser. It will get the attributes from the type of TMessage type parameter, iterates through the FIX elements with FixStringEnumerable and for each element, if the element's tag had an attribute in the type of TMessage, it will set the value of the element on the TMessage instance, then return the instance.

Added editorconfig.