### PR TITLE
Adding Fix Version (BeginString) validator and absctracting validators

### DIFF
--- a/src/RapideFix/DataTypes/FixMessageContext.cs
+++ b/src/RapideFix/DataTypes/FixMessageContext.cs
@@ -1,0 +1,15 @@
+﻿namespace RapideFix.DataTypes
+{
+  public class FixMessageContext
+  {
+    public SupportedFixVersion FixVersion { get; set; }
+
+    public int LengthTagStartIndex { get; set; }
+
+    public int MessageTypeTagStartIndex { get; set; }
+
+    public int ChecksumTagStartIndex { get; set; }
+
+
+  }
+}

--- a/src/RapideFix/DataTypes/SupportedFixVersion.cs
+++ b/src/RapideFix/DataTypes/SupportedFixVersion.cs
@@ -1,0 +1,64 @@
+﻿using RapideFix.Extensions;
+using System;
+using System.Text;
+
+namespace RapideFix
+{
+  public class SupportedFixVersion
+  {
+    private readonly byte[] _byteValue;
+    private readonly string _versionFix;
+
+    public static readonly SupportedFixVersion Fix42 = new SupportedFixVersion("FIX.4.2");
+    public static readonly SupportedFixVersion Fix43 = new SupportedFixVersion("FIX.4.3");
+    public static readonly SupportedFixVersion Fix44 = new SupportedFixVersion("FIX.4.4");
+    public static readonly SupportedFixVersion Fix50 = new SupportedFixVersion("FIXT.1.1");
+
+    private SupportedFixVersion(string name)
+    {
+      _byteValue = name.ToByteValueAndSOH();
+      _versionFix = name;
+    }
+
+    public static SupportedFixVersion Parse(ReadOnlySpan<byte> fixValue)
+    {
+      if(TryParse(fixValue, out var result))
+      {
+        return result;
+      }
+      throw new NotSupportedException("Given Message Version is not supported.");
+    }
+
+    public static bool TryParse(ReadOnlySpan<byte> fixValue, out SupportedFixVersion parsedValue)
+    {
+      if(fixValue.SequenceEqual(Fix50._byteValue))
+      {
+        parsedValue = Fix50;
+        return true;
+      }
+      if(fixValue.SequenceEqual(Fix44._byteValue))
+      {
+        parsedValue = Fix44;
+        return true;
+      }
+      if(fixValue.SequenceEqual(Fix43._byteValue))
+      {
+        parsedValue = Fix43;
+        return true;
+      }
+      if(fixValue.SequenceEqual(Fix42._byteValue))
+      {
+        parsedValue = Fix42;
+        return true;
+      }
+      parsedValue = default;
+      return false;
+    }
+
+    public override string ToString()
+    {
+      return _versionFix;
+    }
+
+  }
+}

--- a/src/RapideFix/Extensions/IntegerExtensions.cs
+++ b/src/RapideFix/Extensions/IntegerExtensions.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Text;
+
+namespace RapideFix.Extensions
+{
+  public static class IntegerExtensions
+  {
+    public static byte[] ToSOHAndKnownTag(this int fixTag)
+    {
+      var tag = Encoding.ASCII.GetBytes($"{fixTag}=");
+      var result = new byte[tag.Length + 1];
+      result[0] = Constants.SOHByte;
+      Array.Copy(tag, 0, result, 1, tag.Length);
+      return result;
+    }
+
+    public static byte[] ToKnownTag(this int fixTag)
+    {
+      var tag = Encoding.ASCII.GetBytes($"{fixTag}=");
+      var result = new byte[tag.Length];
+      Array.Copy(tag, 0, result, 0, tag.Length);
+      return result;
+    }
+  }
+}

--- a/src/RapideFix/Extensions/StringExtensions.cs
+++ b/src/RapideFix/Extensions/StringExtensions.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Text;
+
+namespace RapideFix.Extensions
+{
+  public static class StringExtensions
+  {
+    public static byte[] ToByteValueAndSOH(this string fixValue)
+    {
+      var value = Encoding.ASCII.GetBytes(fixValue);
+      var result = new byte[value.Length + 1];
+      Array.Copy(value, 0, result, 0, value.Length);
+      result[value.Length] = Constants.SOHByte;
+      return result;
+    }
+
+  }
+}

--- a/src/RapideFix/Factories/MessageContextFactory.cs
+++ b/src/RapideFix/Factories/MessageContextFactory.cs
@@ -1,0 +1,20 @@
+﻿using RapideFix.DataTypes;
+using System;
+
+namespace RapideFix.Factories
+{
+  public class MessageContextFactory
+  {
+    public FixMessageContext Create(Span<byte> data)
+    {
+      var result = new FixMessageContext()
+      {
+        LengthTagStartIndex = data.IndexOf(KnownFixTags.Length),
+        MessageTypeTagStartIndex = data.IndexOf(KnownFixTags.MessageType),
+        ChecksumTagStartIndex = data.IndexOf(KnownFixTags.Checksum),
+      };
+      return result;
+    }
+
+  }
+}

--- a/src/RapideFix/KnownFixTags.cs
+++ b/src/RapideFix/KnownFixTags.cs
@@ -1,6 +1,5 @@
-﻿using System;
+﻿using RapideFix.Extensions;
 using System.Runtime.CompilerServices;
-using System.Text;
 
 namespace RapideFix
 {
@@ -8,9 +7,12 @@ namespace RapideFix
   {
     static KnownFixTags()
     {
-      MessageType = CreateKnownTag(35);
-      Checksum = CreateKnownTag(10);
-      Length = CreateKnownTag(9);
+      MessageType = 35.ToSOHAndKnownTag();
+      Checksum = 10.ToSOHAndKnownTag();
+      Length = 9.ToSOHAndKnownTag();
+      FixVersion = 8.ToKnownTag();
+      SenderCompId = 49.ToSOHAndKnownTag();
+      TargetCompId = 56.ToSOHAndKnownTag();
     }
 
     public static byte[] MessageType { get; }
@@ -19,18 +21,15 @@ namespace RapideFix
 
     public static byte[] Length { get; }
 
+    public static byte[] FixVersion { get; }
+
+    public static byte[] SenderCompId { get; }
+
+    public static byte[] TargetCompId { get; }
+
     [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.NoOptimization)]
     public static void Initialize()
     {
-    }
-
-    private static byte[] CreateKnownTag(int fixTag)
-    {
-      var tag = Encoding.ASCII.GetBytes($"{fixTag}=");
-      var result = new byte[tag.Length + 1];
-      result[0] = Constants.SOHByte;
-      Array.Copy(tag, 0, result, 1, tag.Length);
-      return result;
     }
 
   }

--- a/src/RapideFix/Validation/ChecksumValidator.cs
+++ b/src/RapideFix/Validation/ChecksumValidator.cs
@@ -1,10 +1,9 @@
-﻿using System;
-using System.Runtime.CompilerServices;
-using System.Text;
+﻿using RapideFix.DataTypes;
+using System;
 
 namespace RapideFix.Validation
 {
-  public class ChecksumValidator
+  public class ChecksumValidator : IValidator
   {
     private static readonly int Modulus = 256;
     private static readonly int ChecksumLength = 3;
@@ -15,20 +14,9 @@ namespace RapideFix.Validation
       _converter = converter ?? throw new ArgumentNullException(nameof(converter));
     }
 
-    public bool IsValid(string data)
+    public bool IsValid(Span<byte> data, FixMessageContext msgContext)
     {
-      throw new NotImplementedException();
-    }
-
-    public bool IsValid(Span<byte> data)
-    {
-      int endingTagPos = data.LastIndexOf(KnownFixTags.Checksum);
-      return IsValid(data, endingTagPos);
-    }
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public bool IsValid(Span<byte> data, int endingTagPos)
-    {
+      var endingTagPos = msgContext.ChecksumTagStartIndex;
       if(endingTagPos < 0 || (endingTagPos + KnownFixTags.Checksum.Length + ChecksumLength + 1) != data.Length)
       {
         return false;

--- a/src/RapideFix/Validation/FixVersionValidator.cs
+++ b/src/RapideFix/Validation/FixVersionValidator.cs
@@ -1,0 +1,36 @@
+﻿using RapideFix.DataTypes;
+using System;
+
+namespace RapideFix.Validation
+{
+  public class FixVersionValidator : IValidator
+  {
+    public bool IsValid(Span<byte> data, FixMessageContext messageContext)
+    {
+      if(!data.StartsWith(KnownFixTags.FixVersion))
+      {
+        return false;
+      }
+      int beginStringLength = data.IndexOf(Constants.SOHByte);
+      var fixVersionValue = data.Slice(KnownFixTags.FixVersion.Length, beginStringLength - KnownFixTags.FixVersion.Length + 1);
+      if(!SupportedFixVersion.TryParse(fixVersionValue, out var version))
+      {
+        return false;
+      }
+      messageContext.FixVersion = version;
+      var slice = data.Slice(beginStringLength);
+      bool isValid = true;
+      if(version == SupportedFixVersion.Fix50)
+      {
+        isValid &= slice.IndexOf(KnownFixTags.SenderCompId) >= 0
+          && slice.IndexOf(KnownFixTags.TargetCompId) >= 0;
+      }
+      var msgTypeIndex = messageContext.MessageTypeTagStartIndex;
+      var lengthIndex = messageContext.LengthTagStartIndex;
+      isValid &= msgTypeIndex > 0 && lengthIndex >= 0;
+      return isValid;
+    }
+
+  }
+}
+

--- a/src/RapideFix/Validation/IValidator.cs
+++ b/src/RapideFix/Validation/IValidator.cs
@@ -1,0 +1,13 @@
+﻿using RapideFix.DataTypes;
+using System;
+
+namespace RapideFix.Validation
+{
+  public interface IValidator
+  {
+    /// <summary>
+    /// Returns if the given message is valid.
+    /// </summary>
+    bool IsValid(Span<byte> message, FixMessageContext messageContext);
+  }
+}

--- a/src/RapideFix/Validation/ValidatorCollection.cs
+++ b/src/RapideFix/Validation/ValidatorCollection.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using RapideFix.DataTypes;
+
+namespace RapideFix.Validation
+{
+  public class ValidatorCollection : IValidator
+  {
+    private readonly List<IValidator> _validators;
+
+    public ValidatorCollection(IntegerToFixConverter integerConverter)
+    {
+      _validators = new List<IValidator>();
+      _validators.Add(new FixVersionValidator());
+      _validators.Add(new ChecksumValidator(integerConverter));
+      _validators.Add(new LengthValidator(integerConverter));
+    }
+
+    public bool IsValid(Span<byte> message, FixMessageContext messageContext)
+    {
+      if(messageContext == null)
+      {
+        throw new ArgumentNullException(nameof(messageContext));
+      }
+      foreach(var validator in _validators)
+      {
+        if(!validator.IsValid(message, messageContext))
+        {
+          return false;
+        }
+      }
+      return true;
+    }
+  }
+}

--- a/tests/RapidFixFixture/DataTypes/SupportedFixVersionTests.cs
+++ b/tests/RapidFixFixture/DataTypes/SupportedFixVersionTests.cs
@@ -1,0 +1,52 @@
+﻿using RapideFix;
+using RapideFix.Extensions;
+using System;
+using Xunit;
+
+namespace RapideFixFixture.DataTypes
+{
+  public class SupportedFixVersionTests
+  {
+    [Fact]
+    public void GivenSupportedFixVersion_ToString_ReturnsNotEmpty()
+    {
+      Assert.NotEmpty(SupportedFixVersion.Fix50.ToString());
+      Assert.NotEmpty(SupportedFixVersion.Fix44.ToString());
+      Assert.NotEmpty(SupportedFixVersion.Fix43.ToString());
+      Assert.NotEmpty(SupportedFixVersion.Fix42.ToString());
+    }
+
+    [Fact]
+    public void GivenSupportedFixVersionBytes_Parse_ReturnsObject()
+    {
+      var byteRepresentation = SupportedFixVersion.Fix43.ToString().ToByteValueAndSOH();
+      var parsed = SupportedFixVersion.Parse(byteRepresentation.AsSpan());
+      Assert.Equal(SupportedFixVersion.Fix43, parsed);
+    }
+
+    [Fact]
+    public void GivenSupportedFixVersionBytes_TryParse_ReturnsTrue()
+    {
+      var byteRepresentation = SupportedFixVersion.Fix50.ToString().ToByteValueAndSOH();
+      var result = SupportedFixVersion.TryParse(byteRepresentation.AsSpan(), out var parsed);
+      Assert.Equal(SupportedFixVersion.Fix50, parsed);
+      Assert.True(result);
+    }
+
+    [Fact]
+    public void GivenInvalidSupportedFixVersionBytes_Parse_ThrowsNotSupportedException()
+    {
+      var byteRepresentation = SupportedFixVersion.Fix43.ToString().ToByteValueAndSOH();
+      Assert.Throws<NotSupportedException>(() => SupportedFixVersion.Parse(byteRepresentation.AsSpan(1)));
+    }
+
+    [Fact]
+    public void GivenInvalidSupportedFixVersionBytes_TryParse_ReturnsFalse()
+    {
+      var byteRepresentation = SupportedFixVersion.Fix50.ToString().ToByteValueAndSOH();
+      var result = SupportedFixVersion.TryParse(byteRepresentation.AsSpan(1), out var parsed);
+      Assert.False(result);
+    }
+
+  }
+}

--- a/tests/RapidFixFixture/Extensions/IntegerExtensionsTests.cs
+++ b/tests/RapidFixFixture/Extensions/IntegerExtensionsTests.cs
@@ -1,0 +1,32 @@
+﻿using RapideFix;
+using RapideFix.Extensions;
+using System;
+using System.Text;
+using Xunit;
+
+namespace RapideFixFixture.Extensions
+{
+  public class IntegerExtensionsTests
+  {
+    [Theory]
+    [InlineData(9)]
+    [InlineData(23)]
+    public void GivenInteger_ToSOHAndKnownTag_ConvertsValue(int tag)
+    {
+      byte[] result = tag.ToSOHAndKnownTag();
+      Assert.Equal(Constants.SOHByte, result[0]);
+      var resultString = Encoding.ASCII.GetString(result.AsSpan(1));
+      Assert.Equal($"{tag}=", resultString);
+    }
+
+    [Theory]
+    [InlineData(8)]
+    [InlineData(231)]
+    public void GivenInteger_ToKnownTag_ConvertsValue(int tag)
+    {
+      byte[] result = tag.ToKnownTag();
+      var resultString = Encoding.ASCII.GetString(result);
+      Assert.Equal($"{tag}=", resultString);
+    }
+  }
+}

--- a/tests/RapidFixFixture/Extensions/StringExtensionsTests.cs
+++ b/tests/RapidFixFixture/Extensions/StringExtensionsTests.cs
@@ -1,0 +1,23 @@
+﻿using RapideFix;
+using RapideFix.Extensions;
+using System;
+using System.Text;
+using Xunit;
+
+namespace RapideFixFixture.Extensions
+{
+  public class StringExtensionsTests
+  {
+    [Theory]
+    [InlineData("value")]
+    [InlineData("otherValue")]
+    public void GivenString_ToByteValueAndSOH_ReturnsBytesAndSOH(string value)
+    {
+      byte[] result = value.ToByteValueAndSOH();
+      Assert.Equal(Constants.SOHByte, result[result.Length - 1]);
+      var resultString = Encoding.ASCII.GetString(result.AsSpan(0, result.Length - 1));
+      Assert.Equal(value, resultString);
+    }
+
+  }
+}

--- a/tests/RapidFixFixture/Factories/MessageContextFactoryTests.cs
+++ b/tests/RapidFixFixture/Factories/MessageContextFactoryTests.cs
@@ -1,0 +1,22 @@
+﻿using RapideFix.DataTypes;
+using RapideFix.Factories;
+using Xunit;
+
+namespace RapideFixFixture.Factories
+{
+  public class MessageContextFactoryTests
+  {
+    [Fact]
+    public void GivenSampleMessage_Create_ReturnsMessageContext()
+    {
+      var message = new TestFixMessageBuilder(TestFixMessageBuilder.DefaultBody).Build();
+      var uut = new MessageContextFactory();
+      FixMessageContext result = uut.Create(message);
+
+      Assert.NotEqual(-1, result.ChecksumTagStartIndex);
+      Assert.NotEqual(-1, result.LengthTagStartIndex);
+      Assert.NotEqual(-1, result.MessageTypeTagStartIndex);
+    }
+
+  }
+}

--- a/tests/RapidFixFixture/TestFixMessageBuilder.cs
+++ b/tests/RapidFixFixture/TestFixMessageBuilder.cs
@@ -9,6 +9,7 @@ namespace RapideFixFixture
   {
     private StringBuilder _tags;
     private string _length;
+    private string _beginString;
 
     public static readonly string DefaultBody = "35=A|49=SERVER|56=CLIENT|34=177|52=20090107-18:15:16|98=0|108=30|";
 
@@ -51,10 +52,22 @@ namespace RapideFixFixture
       return this;
     }
 
+    public TestFixMessageBuilder AddBeginString(SupportedFixVersion version)
+    {
+      _beginString = $"8={version}|";
+      return this;
+    }
+
+    public TestFixMessageBuilder AddBeginString(string beginString)
+    {
+      _beginString = beginString;
+      return this;
+    }
+
     public byte[] Build()
     {
       StringBuilder sb = new StringBuilder();
-      sb.Append("8=FIX.4.2|");
+      sb.Append(_beginString ?? "8=FIX.4.2|");
       sb.Append(GetLength());
       sb.Append(_tags, 0, _tags.Length);
       var headerAndBody = sb.Replace(Constants.VerticalBar, Constants.SOHChar).ToString();
@@ -64,7 +77,7 @@ namespace RapideFixFixture
     public byte[] Build(string checksum)
     {
       StringBuilder sb = new StringBuilder();
-      sb.Append("8=FIX.4.2|");
+      sb.Append(_beginString ?? "8=FIX.4.2|");
       sb.Append(GetLength());
       this.AddTag(checksum);
       sb.Append(_tags, 0, _tags.Length);
@@ -76,7 +89,7 @@ namespace RapideFixFixture
     {
       if(string.IsNullOrEmpty(_length))
       {
-        return  $"9={_tags.Length}{Constants.VerticalBar}";
+        return $"9={_tags.Length}{Constants.VerticalBar}";
       }
       return _length;
     }

--- a/tests/RapidFixFixture/Validation/ChecksumValidatorTests.cs
+++ b/tests/RapidFixFixture/Validation/ChecksumValidatorTests.cs
@@ -1,4 +1,5 @@
 ﻿using RapideFix;
+using RapideFix.Factories;
 using RapideFix.Validation;
 using System;
 using Xunit;
@@ -13,7 +14,8 @@ namespace RapideFixFixture.Validation
     {
       byte[] message = new TestFixMessageBuilder(input).Build();
       var uut = new ChecksumValidator(new IntegerToFixConverter());
-      var result = uut.IsValid(message.AsSpan());
+      var msgContext = new MessageContextFactory().Create(message);
+      var result = uut.IsValid(message.AsSpan(), msgContext);
       Assert.True(result);
     }
 
@@ -22,7 +24,8 @@ namespace RapideFixFixture.Validation
     {
       var message = new TestFixMessageBuilder(TestFixMessageBuilder.DefaultBody).Build(checksum: "10=023|");
       var uut = new ChecksumValidator(new IntegerToFixConverter());
-      var result = uut.IsValid(message.AsSpan());
+      var msgContext = new MessageContextFactory().Create(message);
+      var result = uut.IsValid(message.AsSpan(), msgContext);
       Assert.False(result);
     }
 
@@ -31,7 +34,8 @@ namespace RapideFixFixture.Validation
     {
       var message = new TestFixMessageBuilder(TestFixMessageBuilder.DefaultBody).Build(checksum: "10=3|");
       var uut = new ChecksumValidator(new IntegerToFixConverter());
-      var result = uut.IsValid(message.AsSpan());
+      var msgContext = new MessageContextFactory().Create(message);
+      var result = uut.IsValid(message.AsSpan(), msgContext);
       Assert.False(result);
     }
 
@@ -40,7 +44,8 @@ namespace RapideFixFixture.Validation
     {
       var message = new TestFixMessageBuilder(TestFixMessageBuilder.DefaultBody).Build(checksum: "11=3|");
       var uut = new ChecksumValidator(new IntegerToFixConverter());
-      var result = uut.IsValid(message.AsSpan());
+      var msgContext = new MessageContextFactory().Create(message);
+      var result = uut.IsValid(message.AsSpan(), msgContext);
       Assert.False(result);
     }
 

--- a/tests/RapidFixFixture/Validation/FixVersionValidatorTests.cs
+++ b/tests/RapidFixFixture/Validation/FixVersionValidatorTests.cs
@@ -1,0 +1,63 @@
+﻿using RapideFix;
+using RapideFix.Factories;
+using RapideFix.Validation;
+using System;
+using Xunit;
+
+namespace RapideFixFixture.Validation
+{
+  public class FixVersionValidatorTests
+  {
+    [Theory]
+    [MemberData(nameof(SampleFixMessagesSource.GetSampleFixBodies), MemberType = typeof(SampleFixMessagesSource))]
+    public void GivenValidFixVersion_Validate_ReturnsTrue(string input)
+    {
+      byte[] message = new TestFixMessageBuilder(input).Build();
+      var uut = new FixVersionValidator();
+      var msgContext = new MessageContextFactory().Create(message);
+      var result = uut.IsValid(message.AsSpan(), msgContext);
+      Assert.True(result);
+    }
+
+    [Fact]
+    public void GivenInvalidVersion_Validate_ReturnsFalse()
+    {
+      var message = new TestFixMessageBuilder(TestFixMessageBuilder.DefaultBody).AddBeginString("8=123|").Build();
+      var uut = new FixVersionValidator();
+      var msgContext = new MessageContextFactory().Create(message);
+      var result = uut.IsValid(message.AsSpan(), msgContext);
+      Assert.False(result);
+    }
+
+    [Fact]
+    public void GivenNoBeginString_Validate_ReturnsFalse()
+    {
+      var message = new TestFixMessageBuilder(TestFixMessageBuilder.DefaultBody).AddBeginString(string.Empty).Build();
+      var uut = new FixVersionValidator();
+      var msgContext = new MessageContextFactory().Create(message);
+      var result = uut.IsValid(message.AsSpan(), msgContext);
+      Assert.False(result);
+    }
+
+    [Fact]
+    public void GivenFix5WithNoTargetCompId_Validate_ReturnsFalse()
+    {
+      var message = new TestFixMessageBuilder("35=A|49=SERVER|34=177|52=20090107-18:15:16|98=0|108=30|").AddBeginString(SupportedFixVersion.Fix50).Build();
+      var uut = new FixVersionValidator();
+      var msgContext = new MessageContextFactory().Create(message);
+      var result = uut.IsValid(message.AsSpan(), msgContext);
+      Assert.False(result);
+    }
+
+    [Fact]
+    public void GivenFix5WithNoSenderCompId_Validate_ReturnsFalse()
+    {
+      var message = new TestFixMessageBuilder("35=A|56=CLIENT|34=177|52=20090107-18:15:16|98=0|108=30|").AddBeginString(SupportedFixVersion.Fix50).Build();
+      var uut = new FixVersionValidator();
+      var msgContext = new MessageContextFactory().Create(message);
+      var result = uut.IsValid(message.AsSpan(), msgContext);
+      Assert.False(result);
+    }
+
+  }
+}

--- a/tests/RapidFixFixture/Validation/LengthValidatorTests.cs
+++ b/tests/RapidFixFixture/Validation/LengthValidatorTests.cs
@@ -1,4 +1,6 @@
 ﻿using RapideFix;
+using RapideFix.Factories;
+using RapideFix.Validation;
 using System;
 using System.Diagnostics;
 using Xunit;
@@ -20,7 +22,8 @@ namespace RapideFixFixture.Validation
     {
       byte[] message = new TestFixMessageBuilder(input).Build();
       var uut = new LengthValidator(new IntegerToFixConverter());
-      var result = uut.IsValid(message.AsSpan());
+      var msgContext = new MessageContextFactory().Create(message);
+      var result = uut.IsValid(message.AsSpan(), msgContext);
       Assert.True(result);
     }
 
@@ -30,12 +33,13 @@ namespace RapideFixFixture.Validation
       byte[] message = TestFixMessageBuilder.CreateDefaultMessage();
 
       var uut = new LengthValidator(new IntegerToFixConverter());
-      var result = uut.IsValid(message.AsSpan());
+      var msgContext = new MessageContextFactory().Create(message);
+      var result = uut.IsValid(message.AsSpan(), msgContext);
       Stopwatch sw = new Stopwatch();
       sw.Start();
       for(int i = 0; i < 100; i++)
       {
-        result = uut.IsValid(message.AsSpan());
+        result = uut.IsValid(message.AsSpan(), msgContext);
       }
       sw.Stop();
 
@@ -47,7 +51,8 @@ namespace RapideFixFixture.Validation
     {
       var message = new TestFixMessageBuilder(TestFixMessageBuilder.DefaultBody).AddLength("9=023|").Build();
       var uut = new LengthValidator(new IntegerToFixConverter());
-      var result = uut.IsValid(message.AsSpan());
+      var msgContext = new MessageContextFactory().Create(message);
+      var result = uut.IsValid(message.AsSpan(), msgContext);
       Assert.False(result);
     }
 
@@ -56,7 +61,8 @@ namespace RapideFixFixture.Validation
     {
       var message = new TestFixMessageBuilder(TestFixMessageBuilder.DefaultBody).AddLength("9=|").Build();
       var uut = new LengthValidator(new IntegerToFixConverter());
-      var result = uut.IsValid(message.AsSpan());
+      var msgContext = new MessageContextFactory().Create(message);
+      var result = uut.IsValid(message.AsSpan(), msgContext);
       Assert.False(result);
     }
 
@@ -65,7 +71,8 @@ namespace RapideFixFixture.Validation
     {
       var message = new TestFixMessageBuilder(TestFixMessageBuilder.DefaultBody).AddLength("9=3|").Build();
       var uut = new LengthValidator(new IntegerToFixConverter());
-      var result = uut.IsValid(message.AsSpan());
+      var msgContext = new MessageContextFactory().Create(message);
+      var result = uut.IsValid(message.AsSpan(), msgContext);
       Assert.False(result);
     }
 

--- a/tests/RapidFixFixture/Validation/ValidatorCollectionTests.cs
+++ b/tests/RapidFixFixture/Validation/ValidatorCollectionTests.cs
@@ -1,0 +1,37 @@
+﻿using RapideFix;
+using RapideFix.Factories;
+using RapideFix.Validation;
+using System;
+using Xunit;
+
+namespace RapideFixFixture.Validation
+{
+  public class ValidatorCollectionTests
+  {
+    [Fact]
+    public void GivenDependencies_Construct_DoesNotThrow()
+    {
+      var record = Record.Exception(() => new ValidatorCollection(new IntegerToFixConverter()));
+      Assert.Null(record);
+    }
+
+    [Fact]
+    public void GivenMessageContext_IsValid_ReturnsTrue()
+    {
+      var uut = new ValidatorCollection(new IntegerToFixConverter());
+      var message = new TestFixMessageBuilder(TestFixMessageBuilder.DefaultBody).Build();
+      var msgCtx = new MessageContextFactory().Create(message);
+
+      Assert.True(uut.IsValid(message, msgCtx));
+    }
+
+    [Fact]
+    public void GivenNoMessageContext_IsValid_ThrowsArgumentNullException()
+    {
+      var uut = new ValidatorCollection(new IntegerToFixConverter());
+      var message = new TestFixMessageBuilder(TestFixMessageBuilder.DefaultBody).Build();
+      Assert.Throws<ArgumentNullException>(() => uut.IsValid(message, null));
+    }
+
+  }
+}


### PR DESCRIPTION
Adding a FixMessageContext to hold 'well-known' info about the fix message attributes.
Creating a FixMessageContextFactory, which create the message context, and calculate common tag positions once.
Adding a validator collection and a validator interface for abstracting away all the validators
Creating a SupportedFixVersion class for the fix versions to support.
Adding a fix version validator, which validates if the message is supported, and if the header tags are available for that required version.
Updating unit tests.